### PR TITLE
Bundler no longer preloads Date class

### DIFF
--- a/ruby-freshbooks.gemspec
+++ b/ruby-freshbooks.gemspec
@@ -1,3 +1,5 @@
+require "date"
+
 Gem::Specification.new do |s|
   s.name = %q{ruby-freshbooks}
   s.version = File.read(File.join(File.dirname(__FILE__),'VERSION')).chomp


### PR DESCRIPTION
@bbmreed Figured out the issue I was running into the other day -- new bundler versions are no longer preloading the Date class, so any time I bundled I was hitting:

```
Invalid gemspec in [/home/vagrant/.rvm/gems/ruby-2.4.1/bundler/gems/ruby-freshbooks-f141b52c0783/ruby-freshbooks.gemspec]: uninitialized constant Gem::Specification::Date
Did you mean?  Data
/home/vagrant/.rvm/rubies/ruby-2.4.1/lib/ruby/site_ruby/2.4.0/rubygems/stub_specification.rb:158:in `name': undefined method `name' for nil:NilClass (NoMethodError)
```
https://github.com/bundler/bundler/issues/5470
